### PR TITLE
Change the innodb footprint  and enable log for no using index querys

### DIFF
--- a/MySQL/my.cnf
+++ b/MySQL/my.cnf
@@ -125,6 +125,8 @@ log_error = /var/log/mysql/error.log
 slow_query_log_file	=  /apps/mysql/database-slow.log
 long_query_time = 2
 slow_query_log = 1
+log-queries-not-using-indexes
+
 #
 # The following can be used as easy to replay backup logs or for replication.
 # note: if you are setting up a replication slave, see README.Debian about
@@ -143,12 +145,13 @@ max_binlog_size         = 100M
 innodb_file_per_table
 innodb_flush_method=O_DIRECT
 innodb_log_file_size=1G
-innodb_buffer_pool_size=4G
+innodb_buffer_pool_size=2G
 #innodb_log_file_size=256M
 #innodb_buffer_pool_size=2048M
-innodb_buffer_pool_instances=0 
+innodb_buffer_pool_instances=2
 #innodb_flush_method=O_DIRECT
 innodb_io_capacity=1000
+innodb_ft_total_cache_size=32000000
 
 
 


### PR DESCRIPTION
Cambios en las memorias internas de MySQL para el motor de innodb.

1.  innodb_buffer_pool_size
2. innodb_ft_total_cache_size
3. innodb_buffer_pool_instances

Ademas he añadido también el log de querys sin indices